### PR TITLE
Feature/oracle factory update doc

### DIFF
--- a/documentation/SUMMARY.md
+++ b/documentation/SUMMARY.md
@@ -34,6 +34,7 @@
     * [createOracle](tools/oracle-factory/methods/createoracle.md)
     * [readOracle](tools/oracle-factory/methods/readoracle.md)
     * [updateOracle](tools/oracle-factory/methods/updateoracle.md)
+  * [Advanced configuration](tools/oracle-factory/advanced-configuration.md)
 ## Help
 
 - [🆘 Contact us](help/contact-us.md)

--- a/documentation/tools/oracle-factory/README.md
+++ b/documentation/tools/oracle-factory/README.md
@@ -4,7 +4,7 @@ Oracle Factory introduces a streamlined and efficient way for developers to inte
 
 Key features of Oracle Factory include:
 
-* **Create Oracle**—This method allows for the creation of custom oracles from any API, with a limitation of one data return per oracle. This feature is pivotal in fetching specific, relevant data for decentralized applications.
+* **Create Oracle**—This method allows for the creation of custom oracles from any API, with a limitation of one data return per oracle. This feature is pivotal in fetching specific, relevant data for decentralized applications, Oracles can be created solely from APIs to return data types such as 'number', 'string', and 'boolean', ensuring flexibility and compatibility with various data sources.
 * **Update Oracle**—This method ensures that the oracle stays current by fetching the latest data from its linked API. It maintains the oracle's relevance and accuracy, crucial for real-time data-dependent applications.
 * **Read Oracle**—This method allows users to retrieve the value from the oracle.
 

--- a/documentation/tools/oracle-factory/advanced-configuration.md
+++ b/documentation/tools/oracle-factory/advanced-configuration.md
@@ -1,0 +1,62 @@
+# Advanced configuration
+
+The `IExecOracleFactory` constructor accepts configuration options object.
+As these options are very specific, you won't need to use them for a standard usage of `@iexec/iexec-oracle-factory-wrapper`.
+
+```js
+new IExecOracleFactory(ethProvider, options);
+```
+
+## Options
+
+### oracleApp
+
+The Ethereum contract address or ENS (Ethereum Name Service) for the generic oracle dapp.
+
+If not provided, the default ENS `oracle-factory.apps.iexec.eth` pointing to the latest version of the dapp provided by iExec will be used.
+
+```js
+new IExecOracleFactory(ethProvider, {
+  oracleApp: "oracle-factory.apps.iexec.eth",
+});
+```
+
+### oracleContract
+
+You can also customize which smart contract is being used to save oracles values to.
+
+If not provided, the default smart contract address provided by iExec will be used.
+
+```js
+new IExecOracleFactory(ethProvider, {
+  oracleContract: "0x781482C39CcE25546583EaC4957Fb7Bf04C277D2",
+});
+```
+
+### ipfsNode
+
+The IPFS node URL for content uploads. Use this option if you want to use your own IPFS node to upload content.
+
+If not provided, the default IPFS node provided by iExec will be used.
+
+```js
+new IExecOracleFactory(ethProvider, {
+  ipfsNode: "https://ipfs-upload.v8-bellecour.iex.ec",
+});
+```
+
+### ipfsGateway
+
+The IPFS gateway URL used for content downloads. Mainly used for checking content uploaded on the IPFS network. Use this option if you want to use your own IPFS node for content downloads.
+
+If not provided, the default IPFS gateway provided by iExec will be used.
+
+```js
+new IExecOracleFactory(ethProvider, {
+  ipfsGateway: "https://ipfs-gateway.v8-bellecour.iex.ec",
+});
+```
+
+### iexecOptions
+
+Low level configuration options for `iexec` SDK, see [iexec SDK documentation IExecConfigOptions](https://github.com/iExecBlockchainComputing/iexec-sdk/blob/master/docs/interfaces/internal_.IExecConfigOptions.md) for more details.

--- a/documentation/tools/oracle-factory/methods/createoracle.md
+++ b/documentation/tools/oracle-factory/methods/createoracle.md
@@ -6,7 +6,7 @@ As an example below, following coingecko public API which gives ethereum price i
 ## Usage
 
 ```javascript
-const createOracleRes = await factory.createOracle({
+const createOracleRes = factory.createOracle({
   url: "https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd",
   method: "GET",
   headers: {
@@ -15,25 +15,41 @@ const createOracleRes = await factory.createOracle({
   dataType: "number",
   JSONPath: "$.ethereum.usd",
   apiKey: "MY_TEST_API_KEY",
-});
+}).subscribe({
+    next: (data) => {
+      console.log("next", data);
+    },
+    error: (error) => {
+      console.log("error", error);
+    },
+    complete: () => {
+      console.log("Oracle Creation Completed");
+    }, 
+  });
 ```
 
-## Return value example
+## Return values during creation process
 
-```javascript
-{
-  paramSet: {
-    JSONPath: '$.ethereum.usd',
-    body: '',
-    dataType: 'number',
-    dataset: '0x0eFf9Ba4304D5d3EB775cA9dB1F011e65C2eb0cE',
-    headers: { authorization: '%API_KEY%' },
-    method: 'GET',
-    url: 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd'
-  },
-  cid: 'QmbXhtjAJysMMA69KkB8KohsEDTZA2PXuhYdAQcHjjQFit'
-}
-```
+These are the possible events iExec may send to the subscriber:
+
+| message                              | sent                 | additional entries                          |
+| ------------------------------------ | -------------------- | ------------------------------------------- |
+| ENCRYPTION_KEY_CREATED               | once if using apiKey | key: String                                 |
+| FILE_ENCRYPTED                       | once if using apiKey | encryptedFile: Buffer<br/> checksum: String |
+| ENCRYPTED_FILE_UPLOADED              | once if using apiKey | cid: String<br/> multiaddr: String          |
+| DATASET_DEPLOYMENT_SIGN_TX_REQUEST   | once if using apiKey |                                             |
+| DATASET_DEPLOYMENT_SUCCESS           | once if using apiKey | address: String<br/> txHash: String         |
+| PUSH_SECRET_TO_SMS_SIGN_REQUEST      | once if using apiKey |                                             |
+| PUSH_SECRET_TO_SMS_SUCCESS           | once if using apiKey |                                             |
+| DATASET_ORDER_SIGNATURE_SIGN_REQUEST | once if using apiKey | order: Object                               |
+| DATASET_ORDER_SIGNATURE_SUCCESS      | once if using apiKey | order: Object                               |
+| DATASET_ORDER_PUBLISH_SIGN_REQUEST   | once if using apiKey | order: Object                               |
+| DATASET_ORDER_PUBLISH_SUCCESS        | once if using apiKey | orderHash: String                           |
+| PARAM_SET_CREATED                    | once                 | paramSet: String                            |
+| ORACLE_ID_COMPUTED                   | once                 | oracleId: String                            |
+| PARAM_SET_UPLOADED                   | once                 | cid: String                                 |
+| COMPLETED                            | once                 |                                             |
+
 
 ## Parameters
 
@@ -41,60 +57,120 @@ const createOracleRes = await factory.createOracle({
 
 The API URL to fetch data from.
 
-<pre class="language-javascript"><code class="lang-javascript">const createOracleRes = await factory.createOracle({
+<pre class="language-javascript"><code class="lang-javascript">const createOracleRes = factory.createOracle({
 <strong>    url: "https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd",
 </strong>    // Other parameters...
-})
+}).subscribe({
+    next: (data) => {
+      console.log("next", data);
+    },
+    error: (error) => {
+      console.log("error", error);
+    },
+    complete: () => {
+      console.log("Oracle Creation Completed");
+    }, 
+  });
 </code></pre>
 
 ### method
 
 The HTTP method to use when making the API request (e.g., "GET").
 
-<pre class="language-javascript"><code class="lang-javascript">const createOracleRes = await factory.createOracle({
+<pre class="language-javascript"><code class="lang-javascript">const createOracleRes = factory.createOracle({
 <strong>    method: "GET",
 </strong>    // Other parameters...
-})
+}).subscribe({
+    next: (data) => {
+      console.log("next", data);
+    },
+    error: (error) => {
+      console.log("error", error);
+    },
+    complete: () => {
+      console.log("Oracle Creation Completed");
+    }, 
+  });
 </code></pre>
 
 ### headers (optional)
 
 Any headers required for the API request.
 
-<pre class="language-javascript"><code class="lang-javascript">const createOracleRes = await factory.createOracle({
+<pre class="language-javascript"><code class="lang-javascript">const createOracleRes = factory.createOracle({
 <strong>    headers: {
         authorization: "%API_KEY%",
     },
 </strong>    // Other parameters...
-})
+}).subscribe({
+    next: (data) => {
+      console.log("next", data);
+    },
+    error: (error) => {
+      console.log("error", error);
+    },
+    complete: () => {
+      console.log("Oracle Creation Completed");
+    }, 
+  });
 </code></pre>
 
 ### dataType
 
 The type of data to be returned (e.g., "number").
 
-<pre class="language-javascript"><code class="lang-javascript">const createOracleRes = await factory.createOracle({
+<pre class="language-javascript"><code class="lang-javascript">const createOracleRes = factory.createOracle({
 <strong>    dataType: "number",
 </strong>    // Other parameters...
-})
+}).subscribe({
+    next: (data) => {
+      console.log("next", data);
+    },
+    error: (error) => {
+      console.log("error", error);
+    },
+    complete: () => {
+      console.log("Oracle Creation Completed");
+    }, 
+  });
 </code></pre>
 
 ### JSONPath
 
 The JSON path to extract the data from the API response.
 
-<pre class="language-javascript"><code class="lang-javascript">const createOracleRes = await factory.createOracle({
+<pre class="language-javascript"><code class="lang-javascript">const createOracleRes = factory.createOracle({
 <strong>    JSONPath: "$.ethereum.usd",
 </strong>    // Other parameters...
-})
+}).subscribe({
+    next: (data) => {
+      console.log("next", data);
+    },
+    error: (error) => {
+      console.log("error", error);
+    },
+    complete: () => {
+      console.log("Oracle Creation Completed");
+    }, 
+  });
 </code></pre>
 
 ### apiKey (optional)
 
 API key if required by the data source.
 
-<pre class="language-javascript"><code class="lang-javascript">const createOracleRes = await factory.createOracle({
+<pre class="language-javascript"><code class="lang-javascript">const createOracleRes = factory.createOracle({
 <strong>    apiKey: "MY_TEST_API_KEY",
 </strong>    // Other parameters...
-})
+}).subscribe({
+    next: (data) => {
+      console.log("next", data);
+    },
+    error: (error) => {
+      console.log("error", error);
+    },
+    complete: () => {
+      console.log("Oracle Creation Completed");
+    }, 
+  });
 </code></pre>

--- a/documentation/tools/oracle-factory/methods/createoracle.md
+++ b/documentation/tools/oracle-factory/methods/createoracle.md
@@ -1,9 +1,10 @@
 # createOracle
 
-Method to create an oracle from a given API, limited to returning only one data point.
-As an example below, following coingecko public API which gives ethereum price in usd will be used : https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd
+The createOracle method is designed to facilitate the creation of an oracle, which serves as a reliable source of real-time data from a specified Application Programming Interface (API). This method is particularly suited for scenarios where only a single data point is required from the API.
 
 ## Usage
+
+As an example, we will utilize the CoinGecko public API, which provides the Ethereum price in USD: <a href="https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd">CoinGecko Ethereum API</a>.
 
 ```javascript
 const createOracleRes = factory.createOracle({

--- a/documentation/tools/oracle-factory/methods/readoracle.md
+++ b/documentation/tools/oracle-factory/methods/readoracle.md
@@ -1,17 +1,19 @@
 # readOracle
 
-Method to retrieve the value from a specific oracle.
-The example below is based on an oracle created using the following public API which provides
-the price of Ethereum in USD:
-[https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd](https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd)
+The readOracle method is designed to retrieve the value from a specific oracle. This enables users to access data fetched by an oracle, which serves as a reliable source of information sourced from external APIs or other data providers.
 
 ## Usage
 
+As an example, we will utilize the CoinGecko public API oracle, which provides the Ethereum price in USD: <a href="https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd">CoinGecko Ethereum API</a>.
+
 ```javascript
-const readOracleRes = await factory.readOracle(
+const readOracleRes = await readerOrFactory.readOracle(
   "QmbXhtjAJysMMA69KkB8KohsEDTZA2PXuhYdAQcHjjQFit"
 ); // Content ID of the Oracle
 ```
+{% hint style="info" %}
+You can utilize either type of SDK instance, be it the basic IExecOracleFactory or the IExecOracleReader, to invoke the readOracle method.
+{% endhint %}
 
 ## Return value example
 
@@ -28,7 +30,7 @@ const readOracleRes = await factory.readOracle(
 
 Content ID of the Oracle to be read.
 
-<pre class="language-javascript"><code class="lang-javascript">const readOracleRes = await factory.readOracle(
+<pre class="language-javascript"><code class="lang-javascript">const readOracleRes = await readerOrFactory.readOracle(
 <strong>  "QmbXhtjAJysMMA69KkB8KohsEDTZA2PXuhYdAQcHjjQFit"
 </strong>);
 </code></pre>

--- a/documentation/tools/oracle-factory/methods/updateoracle.md
+++ b/documentation/tools/oracle-factory/methods/updateoracle.md
@@ -7,22 +7,44 @@ Below, following public API which gives ethereum price in usd will be used : htt
 ## Usage
 
 ```javascript
-const updateOracleRes = await factory.updateOracle({
+const updateOracleRes = factory.updateOracle({
   cid: "QmbXhtjAJysMMA69KkB8KohsEDTZA2PXuhYdAQcHjjQFit", // Content ID of the Oracle
   workerpool: "0x0e7bc972c99187c191a17f3cae4a2711a4188c3f", // Workerpool address (required)
   targetBlockchains: ["134", "137"], // Target blockchain IDs, 137 for polygon, 134 for iExec (required)
-});
+}).subscribe({
+    next: (data) => {
+      console.log("next", data);
+    },
+    error: (error) => {
+      console.log("error", error);
+    },
+    complete: () => {
+      console.log("Oracle update Completed");
+    }, 
+  });
 ```
 
 ## Return value example
 
-```javascript
-{
-  dealid: '0x86e1d2b13cd176f86b2c9d10931bc20dba0d626f1dac07dd76c1b1cec569f232',
-  taskid: '0x90a100c10780f1d0595dd9e37dc1655eb66f192bf1b2b31d719a6ca3c6b62d07',
-  status: 'REVEALING'
-}
-```
+These are the possible events iExec may send to the subscriber:
+
+| message                              | sent                  | additional entries                                                                                                         |
+| ------------------------------------ | --------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| ENSURE_PARAMS                        | once                  |                                                                                                                            |
+| ENSURE_PARAMS_SUCCESS                | once                  | paramSet: Object<br/> cid: String                                                                                          |
+| FETCH_APP_ORDER                      | once                  |                                                                                                                            |
+| FETCH_APP_ORDER_SUCCESS              | once                  | order: Object                                                                                                              |
+| FETCH_DATASET_ORDER                  | once if using dataset |                                                                                                                            |
+| FETCH_DATASET_ORDER_SUCCESS          | once if using dataset | order: Object                                                                                                              |
+| FETCH_WORKERPOOL_ORDER               | once                  |                                                                                                                            |
+| FETCH_WORKERPOOL_ORDER_SUCCESS       | once                  | order: Object                                                                                                              |
+| REQUEST_ORDER_SIGNATURE_SIGN_REQUEST | once                  | order: Object                                                                                                              |
+| REQUEST_ORDER_SIGNATURE_SUCCESS      | once                  | order: Object                                                                                                              |
+| MATCH_ORDERS_SIGN_TX_REQUEST         | once                  | apporder: Object<br/> datasetorder: Object<br/> workerpoolorder: Object<br/> requestorder: Object                          |
+| MATCH_ORDERS_SUCCESS                 | once                  | dealid: String<br/> txHash: String                                                                                         |
+| TASK_UPDATED                         | once per task update  | dealid: String<br/> taskid: String<br/> status: 'UNSET' \| 'ACTIVE' \| 'REVEALING' \| 'COMPLETED' \| 'TIMEOUT' \| 'FAILED' |
+| TASK_COMPLETED                       | once                  | dealid: String<br/> taskid: String<br/> status: String                                                                     |
+
 
 ## Parameters
 
@@ -30,10 +52,20 @@ const updateOracleRes = await factory.updateOracle({
 
 Content ID of the Oracle that needs to be updated.
 
-<pre class="language-javascript"><code class="lang-javascript">const updateOracleRes = await factory.updateOracle({
+<pre class="language-javascript"><code class="lang-javascript">const updateOracleRes = factory.updateOracle({
 <strong>    cid: "QmbXhtjAJysMMA69KkB8KohsEDTZA2PXuhYdAQcHjjQFit",
 </strong>    // Other parameters...
-})
+}).subscribe({
+    next: (data) => {
+      console.log("next", data);
+    },
+    error: (error) => {
+      console.log("error", error);
+    },
+    complete: () => {
+      console.log("Oracle update Completed");
+    }, 
+  });
 </code></pre>
 
 ### workerpool
@@ -41,18 +73,38 @@ Content ID of the Oracle that needs to be updated.
 Address of the workerpool that should perform the update.
 Workerpool defined below is : 0x0e7bc972c99187c191a17f3cae4a2711a4188c3f.
 
-<pre class="language-javascript"><code class="lang-javascript">const updateOracleRes = await factory.updateOracle({
+<pre class="language-javascript"><code class="lang-javascript">const updateOracleRes = factory.updateOracle({
 <strong>    workerpool: "0x0e7bc972c99187c191a17f3cae4a2711a4188c3f",
 </strong>    // Other parameters...
-})
+}).subscribe({
+    next: (data) => {
+      console.log("next", data);
+    },
+    error: (error) => {
+      console.log("error", error);
+    },
+    complete: () => {
+      console.log("Oracle update Completed");
+    }, 
+  });
 </code></pre>
 
 ### targetBlockchains (optional)
 
 Array of target blockchain IDs where the oracle is deployed. 137 for polygon, 134 for iExec.
 
-<pre class="language-javascript"><code class="lang-javascript">const updateOracleRes = await factory.updateOracle({
+<pre class="language-javascript"><code class="lang-javascript">const updateOracleRes = factory.updateOracle({
 <strong>    targetBlockchains: ["134", "137"],
 </strong>    // Other parameters...
-})
+}).subscribe({
+    next: (data) => {
+      console.log("next", data);
+    },
+    error: (error) => {
+      console.log("error", error);
+    },
+    complete: () => {
+      console.log("Oracle update Completed");
+    }, 
+  });
 </code></pre>

--- a/documentation/tools/oracle-factory/methods/updateoracle.md
+++ b/documentation/tools/oracle-factory/methods/updateoracle.md
@@ -1,15 +1,14 @@
 # updateOracle
 
-Method to update an existing oracle to have the latest data from the linked API.
-
-Below, following public API which gives ethereum price in usd will be used : https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd
+The updateOracle method serves to refresh an existing oracle with the latest data fetched from the linked API. This ensures that the oracle maintains up-to-date information, enhancing its reliability and usefulness for downstream applications.
 
 ## Usage
+
+As an example, we will utilize the CoinGecko public API oracle, which provides the Ethereum price in USD: <a href="https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd">CoinGecko Ethereum API</a>.
 
 ```javascript
 const updateOracleRes = factory.updateOracle({
   cid: "QmbXhtjAJysMMA69KkB8KohsEDTZA2PXuhYdAQcHjjQFit", // Content ID of the Oracle
-  workerpool: "0x0e7bc972c99187c191a17f3cae4a2711a4188c3f", // Workerpool address (required)
   targetBlockchains: ["134", "137"], // Target blockchain IDs, 137 for polygon, 134 for iExec (required)
 }).subscribe({
     next: (data) => {
@@ -54,27 +53,6 @@ Content ID of the Oracle that needs to be updated.
 
 <pre class="language-javascript"><code class="lang-javascript">const updateOracleRes = factory.updateOracle({
 <strong>    cid: "QmbXhtjAJysMMA69KkB8KohsEDTZA2PXuhYdAQcHjjQFit",
-</strong>    // Other parameters...
-}).subscribe({
-    next: (data) => {
-      console.log("next", data);
-    },
-    error: (error) => {
-      console.log("error", error);
-    },
-    complete: () => {
-      console.log("Oracle update Completed");
-    }, 
-  });
-</code></pre>
-
-### workerpool
-
-Address of the workerpool that should perform the update.
-Workerpool defined below is : 0x0e7bc972c99187c191a17f3cae4a2711a4188c3f.
-
-<pre class="language-javascript"><code class="lang-javascript">const updateOracleRes = factory.updateOracle({
-<strong>    workerpool: "0x0e7bc972c99187c191a17f3cae4a2711a4188c3f",
 </strong>    // Other parameters...
 }).subscribe({
     next: (data) => {

--- a/documentation/tools/oracle-factory/quick-start.md
+++ b/documentation/tools/oracle-factory/quick-start.md
@@ -134,6 +134,8 @@ const mainnetBlockchainReader = new IExecOracleReader('mainnet');
 {% endtabs %}
 {% hint style="info" %}
 You can initialize the IExecOracleReader with the blockchain name or the chain id or even your custom blockchain Endpoint.
+{% endhint %}
+
 Supported blockchains: 
 | blockchain name                      | chainID              | 
 | ------------------------------------ | -------------------- |
@@ -142,5 +144,3 @@ Supported blockchains:
 | bellecour                            | 134                  |
 | polygon                              | 137                  |
 | mumbai                               | 80001                |
-
-{% endhint %}

--- a/documentation/tools/oracle-factory/quick-start.md
+++ b/documentation/tools/oracle-factory/quick-start.md
@@ -112,9 +112,8 @@ Instantiate the SDK in your front-end project:
 ```javascript
 import { IExecOracleReader } from '@iexec/iexec-oracle-factory-wrapper';
 
-const BELLECOUR_BLOCKCHAIN_ENDPOINT = 'https://bellecour.iex.ec';
 // instantiate
-const bellecourBlockchainReader = new IExecOracleReader(BELLECOUR_BLOCKCHAIN_ENDPOINT);
+const mainnetBlockchainReader = new IExecOracleReader('mainnet');
 ```
 
 {% endtab %}
@@ -127,10 +126,21 @@ Instantiate the IExecOracleReader from the Oracle Factory SDK in your back-end p
 ```javascript
 import { IExecOracleReader } from '@iexec/iexec-oracle-factory-wrapper';
 
-const BELLECOUR_BLOCKCHAIN_ENDPOINT = 'https://bellecour.iex.ec';
 // instantiate
-const bellecourBlockchainReader = new IExecOracleReader(BELLECOUR_BLOCKCHAIN_ENDPOINT);
+const mainnetBlockchainReader = new IExecOracleReader('mainnet');
 ```
 
 {% endtab %}
 {% endtabs %}
+{% hint style="info" %}
+You can initialize the IExecOracleReader with the blockchain name or the chain id or even your custom blockchain Endpoint.
+Supported blockchains: 
+| blockchain name                      | chainID              | 
+| ------------------------------------ | -------------------- |
+| mainnet                              | 1                    |
+| goerli                               | 5                    |
+| bellecour                            | 134                  |
+| polygon                              | 137                  |
+| mumbai                               | 80001                |
+
+{% endhint %}

--- a/documentation/tools/oracle-factory/quick-start.md
+++ b/documentation/tools/oracle-factory/quick-start.md
@@ -99,3 +99,39 @@ const factory = new IExecOracleFactory(signer);
 
 {% endtab %}
 {% endtabs %}
+
+### **1.5. Instantiate Only IExecOracleReader**
+
+Import and initialize the IExecOracleReader from the Oracle Factory SDK in your application.
+
+{% tabs %}
+{% tab title="Browser" %}
+Instantiate the SDK in your front-end project:
+
+#### 1.5.1. Basic Instantiation
+
+```javascript
+import { IExecOracleReader } from '@iexec/iexec-oracle-factory-wrapper';
+
+const BELLECOUR_BLOCKCHAIN_ENDPOINT = 'https://bellecour.iex.ec';
+// instantiate
+const bellecourBlockchainReader = new IExecOracleReader(BELLECOUR_BLOCKCHAIN_ENDPOINT);
+```
+
+{% endtab %}
+
+{% tab title="NodeJS" %}
+Instantiate the IExecOracleReader from the Oracle Factory SDK in your back-end project:
+
+#### 1.5.1. Basic Instantiation
+
+```javascript
+import { IExecOracleReader } from '@iexec/iexec-oracle-factory-wrapper';
+
+const BELLECOUR_BLOCKCHAIN_ENDPOINT = 'https://bellecour.iex.ec';
+// instantiate
+const bellecourBlockchainReader = new IExecOracleReader(BELLECOUR_BLOCKCHAIN_ENDPOINT);
+```
+
+{% endtab %}
+{% endtabs %}

--- a/documentation/tools/oracle-factory/quick-start.md
+++ b/documentation/tools/oracle-factory/quick-start.md
@@ -88,7 +88,6 @@ Instantiate the SDK in your back-end project:
 ```javascript
 import { IExecOracleFactory, utils } from "@iexec/iexec-oracle-factory-wrapper";
 
-const { PRIVATE_KEY } = process.env;
 // get web3 provider from a private key
 const signer = utils.getSignerFromPrivateKey(
   "https://bellecour.iex.ec",


### PR DESCRIPTION
# update oracle factory documentation:

- [x] Dans la description de l’oracle, mentionner que les oracles peuvent être créé juste a partir des api pour retourner les types : ‘number’, ‘string’ et ‘boolean’
- [x] en plus de la partie 1.4. Instanciate SDK ajouter la partie de comment instancier IExecOracleReader
- [x] les fonctions createOracle et updateOracle return un Observable et non pas un objet comme c’est documenté, modifier la doc pour l’observable createOracle et updateOracle.
- [x] revoir la documentation de createORacle readORacle and updateOracle, par exemple UpdateORacle n’est pas complète, il manque une brief explication au debut de targetBlockchains 
- [x] ajouter dans la partie de instatiate SDK la possibilité de lire les oracle par IExecOracleReader ; l’utilisateur peut ne pas fournir de provider mais juste le nom du network sur lequel il souhaite lire son oracle 
- [x] retravailler les descriptions des fonctions et des paramètres en général
- [x] ajouter une partie Advanced configuration comme ce qui est fait sur web3mail pour custom optiuons de loracle factory 
