### PR TITLE
Feature/oracle factory twoslash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "@iexec/dataprotector": "^2.0.0-beta.7",
         "@iexec/dataprotector-deserializer": "^0.1.0",
-        "@iexec/iexec-oracle-factory-wrapper": "2.1.0-nightly-6d4efee53d4abf41f12ff21f4e42546890092fa9",
+        "@iexec/iexec-oracle-factory-wrapper": "^2.2.0",
         "@iexec/web3mail": "^1.0.2",
         "vue": "^3.4.21"
       },
@@ -850,9 +850,9 @@
       "integrity": "sha512-z0zMCjyhhp4y7XKAcDAi3Vgms4T2PstwBdahiO0+9NaGICQKjynK3wduSRplTgk4LXmoO1yfDGO5RbjKYxtuxA=="
     },
     "node_modules/@iexec/iexec-oracle-factory-wrapper": {
-      "version": "2.1.0-nightly-6d4efee53d4abf41f12ff21f4e42546890092fa9",
-      "resolved": "https://registry.npmjs.org/@iexec/iexec-oracle-factory-wrapper/-/iexec-oracle-factory-wrapper-2.1.0-nightly-6d4efee53d4abf41f12ff21f4e42546890092fa9.tgz",
-      "integrity": "sha512-aWUr6loT4Hcio295YGyDuiN4aReRhuXq2Wi3InQnVZuuJsujxAQ/nJltlLd/mqxAfdhA+2TVLLvLgIDYgZtjvA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@iexec/iexec-oracle-factory-wrapper/-/iexec-oracle-factory-wrapper-2.2.0.tgz",
+      "integrity": "sha512-Z719KmBkDMjqPTqzioT/Rsi2cF46QF57z4tdxHpdYcXic9Ili1NYO7Eythr3+FIVQnZROKJxXqA2OiETBQh4CA==",
       "dependencies": {
         "big.js": "^6.2.1",
         "buffer": "^6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "@iexec/dataprotector": "^2.0.0-beta.7",
         "@iexec/dataprotector-deserializer": "^0.1.0",
-        "@iexec/iexec-oracle-factory-wrapper": "^2.1.0",
+        "@iexec/iexec-oracle-factory-wrapper": "2.1.0-nightly-6d4efee53d4abf41f12ff21f4e42546890092fa9",
         "@iexec/web3mail": "^1.0.2",
         "vue": "^3.4.21"
       },
@@ -850,17 +850,17 @@
       "integrity": "sha512-z0zMCjyhhp4y7XKAcDAi3Vgms4T2PstwBdahiO0+9NaGICQKjynK3wduSRplTgk4LXmoO1yfDGO5RbjKYxtuxA=="
     },
     "node_modules/@iexec/iexec-oracle-factory-wrapper": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@iexec/iexec-oracle-factory-wrapper/-/iexec-oracle-factory-wrapper-2.1.0.tgz",
-      "integrity": "sha512-209pibPXleyfEVJjGSPWPMw+iY94e4LsXygjURLYoDGCjpEy7WCNGc6e3wzTAs3X/eo+lkNGNK1Ueo8oQyv0PQ==",
+      "version": "2.1.0-nightly-6d4efee53d4abf41f12ff21f4e42546890092fa9",
+      "resolved": "https://registry.npmjs.org/@iexec/iexec-oracle-factory-wrapper/-/iexec-oracle-factory-wrapper-2.1.0-nightly-6d4efee53d4abf41f12ff21f4e42546890092fa9.tgz",
+      "integrity": "sha512-aWUr6loT4Hcio295YGyDuiN4aReRhuXq2Wi3InQnVZuuJsujxAQ/nJltlLd/mqxAfdhA+2TVLLvLgIDYgZtjvA==",
       "dependencies": {
         "big.js": "^6.2.1",
         "buffer": "^6.0.3",
         "cids": "^1.1.9",
         "cross-fetch": "^4.0.0",
         "debug": "^4.3.4",
-        "ethers": "^6.11.0",
-        "iexec": "^8.5.0",
+        "ethers": "^6.13.2",
+        "iexec": "^8.10.0",
         "jsonpath": "^1.1.1",
         "kubo-rpc-client": "^3.0.2",
         "yup": "^1.3.3"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@iexec/dataprotector": "^2.0.0-beta.7",
     "@iexec/dataprotector-deserializer": "^0.1.0",
-    "@iexec/iexec-oracle-factory-wrapper": "^2.1.0",
+    "@iexec/iexec-oracle-factory-wrapper": "2.1.0-nightly-6d4efee53d4abf41f12ff21f4e42546890092fa9",
     "@iexec/web3mail": "^1.0.2",
     "vue": "^3.4.21"
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@iexec/dataprotector": "^2.0.0-beta.7",
     "@iexec/dataprotector-deserializer": "^0.1.0",
-    "@iexec/iexec-oracle-factory-wrapper": "2.1.0-nightly-6d4efee53d4abf41f12ff21f4e42546890092fa9",
+    "@iexec/iexec-oracle-factory-wrapper": "^2.2.0",
     "@iexec/web3mail": "^1.0.2",
     "vue": "^3.4.21"
   }

--- a/tools/oracle-factory/advanced-configuration.md
+++ b/tools/oracle-factory/advanced-configuration.md
@@ -4,7 +4,15 @@ The `IExecOracleFactory` constructor accepts configuration options object. As
 these options are very specific, you won't need to use them for a standard usage
 of `@iexec/iexec-oracle-factory-wrapper`.
 
-```js
+```ts twoslash
+import {
+  IExecOracleFactory,
+  OracleFactoryOptions,
+} from '@iexec/iexec-oracle-factory-wrapper';
+const ethProvider = {} as any;
+const options = {} as OracleFactoryOptions;
+
+// ---cut---
 new IExecOracleFactory(ethProvider, options);
 ```
 
@@ -18,7 +26,14 @@ oracle dApp.
 If not provided, the default ENS `oracle-factory.apps.iexec.eth` pointing to the
 latest version of the dApp provided by iExec will be used.
 
-```js
+```ts twoslash
+import {
+  IExecOracleFactory,
+  OracleFactoryOptions,
+} from '@iexec/iexec-oracle-factory-wrapper';
+const ethProvider = {} as any;
+
+// ---cut---
 new IExecOracleFactory(ethProvider, {
   oracleApp: 'oracle-factory.apps.iexec.eth',
 });
@@ -32,7 +47,14 @@ to.
 If not provided, the default smart contract address provided by iExec will be
 used.
 
-```js
+```ts twoslash
+import {
+  IExecOracleFactory,
+  OracleFactoryOptions,
+} from '@iexec/iexec-oracle-factory-wrapper';
+const ethProvider = {} as any;
+
+// ---cut---
 new IExecOracleFactory(ethProvider, {
   oracleContract: '0x781482C39CcE25546583EaC4957Fb7Bf04C277D2',
 });
@@ -45,7 +67,14 @@ own IPFS node to upload content.
 
 If not provided, the default IPFS node provided by iExec will be used.
 
-```js
+```ts twoslash
+import {
+  IExecOracleFactory,
+  OracleFactoryOptions,
+} from '@iexec/iexec-oracle-factory-wrapper';
+const ethProvider = {} as any;
+
+// ---cut---
 new IExecOracleFactory(ethProvider, {
   ipfsNode: 'https://ipfs-upload.v8-bellecour.iex.ec',
 });
@@ -59,7 +88,14 @@ own IPFS node for content downloads.
 
 If not provided, the default IPFS gateway provided by iExec will be used.
 
-```js
+```ts twoslash
+import {
+  IExecOracleFactory,
+  OracleFactoryOptions,
+} from '@iexec/iexec-oracle-factory-wrapper';
+const ethProvider = {} as any;
+
+// ---cut---
 new IExecOracleFactory(ethProvider, {
   ipfsGateway: 'https://ipfs-gateway.v8-bellecour.iex.ec',
 });
@@ -70,3 +106,17 @@ new IExecOracleFactory(ethProvider, {
 Low level configuration options for `iexec` SDK, see
 [iexec SDK documentation IExecConfigOptions](https://github.com/iExecBlockchainComputing/iexec-sdk/blob/master/docs/interfaces/IExecConfigOptions.md)
 for more details.
+
+```ts twoslash
+import {
+  IExecOracleFactory,
+  OracleFactoryOptions,
+} from '@iexec/iexec-oracle-factory-wrapper';
+const ethProvider = {} as any;
+const iexecOptions = {};
+
+// ---cut---
+new IExecOracleFactory(ethProvider, {
+  iexecOptions,
+});
+```

--- a/tools/oracle-factory/getting-started.md
+++ b/tools/oracle-factory/getting-started.md
@@ -125,7 +125,6 @@ Supported blockchains:
 | mainnet         | 1       |
 | bellecour       | 134     |
 | polygon         | 137     |
-| mumbai          | 80001   |
 
 ## Sandbox
 

--- a/tools/oracle-factory/getting-started.md
+++ b/tools/oracle-factory/getting-started.md
@@ -60,7 +60,13 @@ Import and initialize the Oracle Factory SDK in your application.
 
 ::: code-group
 
-```js [Browser]
+```ts twoslash [Browser]
+declare global {
+  interface Window {
+    ethereum: any;
+  }
+}
+// ---cut---
 import { IExecOracleFactory } from '@iexec/iexec-oracle-factory-wrapper';
 
 const web3Provider = window.ethereum;
@@ -68,7 +74,7 @@ const web3Provider = window.ethereum;
 const factory = new IExecOracleFactory(web3Provider);
 ```
 
-```js [NodeJS]
+```ts twoslash [NodeJS]
 import { IExecOracleFactory, utils } from '@iexec/iexec-oracle-factory-wrapper';
 
 const { PRIVATE_KEY } = process.env;
@@ -89,14 +95,14 @@ your application.
 
 ::: code-group
 
-```js [Browser]
+```ts twoslash [Browser]
 import { IExecOracleReader } from '@iexec/iexec-oracle-factory-wrapper';
 
 // instantiate
 const mainnetBlockchainReader = new IExecOracleReader('mainnet');
 ```
 
-```js [NodeJS]
+```ts twoslash [NodeJS]
 import { IExecOracleReader } from '@iexec/iexec-oracle-factory-wrapper';
 
 // instantiate

--- a/tools/oracle-factory/methods/createOracle.md
+++ b/tools/oracle-factory/methods/createOracle.md
@@ -12,7 +12,12 @@ Ethereum price in USD:
 <a href="https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd">CoinGecko
 Ethereum API</a>.
 
-```js
+```ts twoslash
+import { IExecOracleFactory } from '@iexec/iexec-oracle-factory-wrapper';
+const web3Provider = {} as any;
+const factory = new IExecOracleFactory(web3Provider);
+
+// ---cut---
 const createOracleRes = factory
   .createOracle({
     url: 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd',
@@ -71,7 +76,12 @@ import { type RawParams } from '@iexec/iexec-oracle-factory-wrapper';
 
 The API URL to fetch data from.
 
-```js
+```ts twoslash
+import { IExecOracleFactory } from '@iexec/iexec-oracle-factory-wrapper';
+const web3Provider = {} as any;
+const factory = new IExecOracleFactory(web3Provider);
+
+// ---cut---
 const createOracleRes = factory
   .createOracle({
     url: 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd', // [!code focus]
@@ -102,7 +112,12 @@ const createOracleRes = factory
 
 The HTTP method to use when making the API request (e.g., "GET").
 
-```js
+```ts twoslash
+import { IExecOracleFactory } from '@iexec/iexec-oracle-factory-wrapper';
+const web3Provider = {} as any;
+const factory = new IExecOracleFactory(web3Provider);
+
+// ---cut---
 const createOracleRes = factory
   .createOracle({
     url: 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd',
@@ -134,7 +149,12 @@ const createOracleRes = factory
 Any headers required for the API request.
 
 <!-- prettier-ignore-start -->
-```js
+```ts twoslash
+import { IExecOracleFactory } from '@iexec/iexec-oracle-factory-wrapper';
+const web3Provider = {} as any;
+const factory = new IExecOracleFactory(web3Provider);
+
+// ---cut---
 const createOracleRes = factory.createOracle({
   url: 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd',
   method: 'GET',
@@ -164,7 +184,12 @@ const createOracleRes = factory.createOracle({
 
 The type of data to be returned (e.g., "number").
 
-```js
+```ts twoslash
+import { IExecOracleFactory } from '@iexec/iexec-oracle-factory-wrapper';
+const web3Provider = {} as any;
+const factory = new IExecOracleFactory(web3Provider);
+
+// ---cut---
 const createOracleRes = factory
   .createOracle({
     url: 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd',
@@ -195,7 +220,12 @@ const createOracleRes = factory
 
 The JSON path to extract the data from the API response.
 
-```js
+```ts twoslash
+import { IExecOracleFactory } from '@iexec/iexec-oracle-factory-wrapper';
+const web3Provider = {} as any;
+const factory = new IExecOracleFactory(web3Provider);
+
+// ---cut---
 const createOracleRes = factory
   .createOracle({
     url: 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd',
@@ -226,7 +256,12 @@ const createOracleRes = factory
 
 API key if required by the data source.
 
-```js
+```ts twoslash
+import { IExecOracleFactory } from '@iexec/iexec-oracle-factory-wrapper';
+const web3Provider = {} as any;
+const factory = new IExecOracleFactory(web3Provider);
+
+// ---cut---
 const createOracleRes = factory
   .createOracle({
     url: 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd',
@@ -253,9 +288,15 @@ const createOracleRes = factory
 
 ## Return value
 
-```ts twoslash
-// @errors: 2305
-import { type CreateOracleMessage } from '@iexec/iexec-oracle-factory-wrapper';
-```
-
 `Observable<CreateOracleMessage>`
+
+```ts twoslash
+import type {
+  CreateOracleMessage,
+  //
+  DeployDatasetMessage,
+  CreateParamSetMessage,
+  ComputeOracleIDMessage,
+  UploadParamSetMessage,
+} from '@iexec/iexec-oracle-factory-wrapper';
+```

--- a/tools/oracle-factory/methods/createOracle.md
+++ b/tools/oracle-factory/methods/createOracle.md
@@ -18,51 +18,33 @@ const web3Provider = {} as any;
 const factory = new IExecOracleFactory(web3Provider);
 
 // ---cut---
-const createOracleRes = factory
-  .createOracle({
-    url: 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd',
-    method: 'GET',
-    headers: {
-      authorization: '%API_KEY%',
-    },
-    dataType: 'number',
-    JSONPath: '$.ethereum.usd',
-    apiKey: 'MY_TEST_API_KEY',
-  })
-  .subscribe({
-    next: (data) => {
-      console.log('next', data);
-    },
-    error: (error) => {
-      console.log('error', error);
-    },
-    complete: () => {
-      console.log('Oracle Creation Completed');
-    },
-  });
+// create an observable
+const createOracleObservable = factory.createOracle({
+  url: 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd',
+  method: 'GET',
+  headers: {
+    authorization: '%API_KEY%',
+  },
+  dataType: 'number',
+  JSONPath: '$.ethereum.usd',
+  apiKey: 'MY_TEST_API_KEY',
+});
+
+// subscribe to the observable and start the workflow
+createOracleObservable.subscribe({
+  next: (data) => {
+    console.log('next', data);
+  },
+  error: (error) => {
+    console.log('error', error);
+  },
+  complete: () => {
+    console.log('Oracle Creation Completed');
+  },
+});
 ```
 
-## Return values during creation process
-
-These are the possible events iExec may send to the subscriber:
-
-| message                              | sent                 | additional entries                          |
-| ------------------------------------ | -------------------- | ------------------------------------------- |
-| ENCRYPTION_KEY_CREATED               | once if using apiKey | key: String                                 |
-| FILE_ENCRYPTED                       | once if using apiKey | encryptedFile: Buffer<br/> checksum: String |
-| ENCRYPTED_FILE_UPLOADED              | once if using apiKey | cid: String<br/> multiaddr: String          |
-| DATASET_DEPLOYMENT_SIGN_TX_REQUEST   | once if using apiKey |                                             |
-| DATASET_DEPLOYMENT_SUCCESS           | once if using apiKey | address: String<br/> txHash: String         |
-| PUSH_SECRET_TO_SMS_SIGN_REQUEST      | once if using apiKey |                                             |
-| PUSH_SECRET_TO_SMS_SUCCESS           | once if using apiKey |                                             |
-| DATASET_ORDER_SIGNATURE_SIGN_REQUEST | once if using apiKey | order: Object                               |
-| DATASET_ORDER_SIGNATURE_SUCCESS      | once if using apiKey | order: Object                               |
-| DATASET_ORDER_PUBLISH_SIGN_REQUEST   | once if using apiKey | order: Object                               |
-| DATASET_ORDER_PUBLISH_SUCCESS        | once if using apiKey | orderHash: String                           |
-| PARAM_SET_CREATED                    | once                 | paramSet: String                            |
-| ORACLE_ID_COMPUTED                   | once                 | oracleId: String                            |
-| PARAM_SET_UPLOADED                   | once                 | cid: String                                 |
-| COMPLETED                            | once                 |                                             |
+                                   |
 
 ## Parameters
 
@@ -82,28 +64,16 @@ const web3Provider = {} as any;
 const factory = new IExecOracleFactory(web3Provider);
 
 // ---cut---
-const createOracleRes = factory
-  .createOracle({
-    url: 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd', // [!code focus]
-    method: 'GET',
-    headers: {
-      authorization: '%API_KEY%',
-    },
-    dataType: 'number',
-    JSONPath: '$.ethereum.usd',
-    apiKey: 'MY_TEST_API_KEY',
-  })
-  .subscribe({
-    next: (data) => {
-      console.log('next', data);
-    },
-    error: (error) => {
-      console.log('error', error);
-    },
-    complete: () => {
-      console.log('Oracle Creation Completed');
-    },
-  });
+const createOracleObservable = factory.createOracle({
+  url: 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd', // [!code focus]
+  method: 'GET',
+  headers: {
+    authorization: '%API_KEY%',
+  },
+  dataType: 'number',
+  JSONPath: '$.ethereum.usd',
+  apiKey: 'MY_TEST_API_KEY',
+});
 ```
 
 ### method
@@ -118,28 +88,16 @@ const web3Provider = {} as any;
 const factory = new IExecOracleFactory(web3Provider);
 
 // ---cut---
-const createOracleRes = factory
-  .createOracle({
-    url: 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd',
-    method: 'GET', // [!code focus]
-    headers: {
-      authorization: '%API_KEY%',
-    },
-    dataType: 'number',
-    JSONPath: '$.ethereum.usd',
-    apiKey: 'MY_TEST_API_KEY',
-  })
-  .subscribe({
-    next: (data) => {
-      console.log('next', data);
-    },
-    error: (error) => {
-      console.log('error', error);
-    },
-    complete: () => {
-      console.log('Oracle Creation Completed');
-    },
-  });
+const createOracleObservable = factory.createOracle({
+  url: 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd',
+  method: 'GET', // [!code focus]
+  headers: {
+    authorization: '%API_KEY%',
+  },
+  dataType: 'number',
+  JSONPath: '$.ethereum.usd',
+  apiKey: 'MY_TEST_API_KEY',
+});
 ```
 
 ### headers
@@ -155,7 +113,7 @@ const web3Provider = {} as any;
 const factory = new IExecOracleFactory(web3Provider);
 
 // ---cut---
-const createOracleRes = factory.createOracle({
+const createOracleObservable = factory.createOracle({
   url: 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd',
   method: 'GET',
   headers: { // [!code focus]
@@ -164,17 +122,7 @@ const createOracleRes = factory.createOracle({
   dataType: 'number',
   JSONPath: '$.ethereum.usd',
   apiKey: 'MY_TEST_API_KEY',
-}).subscribe({
-  next: (data) => {
-    console.log("next", data);
-  },
-  error: (error) => {
-    console.log("error", error);
-  },
-  complete: () => {
-    console.log("Oracle Creation Completed");
-  },
-});
+})
 ```
 <!-- prettier-ignore-end -->
 
@@ -190,28 +138,16 @@ const web3Provider = {} as any;
 const factory = new IExecOracleFactory(web3Provider);
 
 // ---cut---
-const createOracleRes = factory
-  .createOracle({
-    url: 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd',
-    method: 'GET',
-    headers: {
-      authorization: '%API_KEY%',
-    },
-    dataType: 'number', // [!code focus]
-    JSONPath: '$.ethereum.usd',
-    apiKey: 'MY_TEST_API_KEY',
-  })
-  .subscribe({
-    next: (data) => {
-      console.log('next', data);
-    },
-    error: (error) => {
-      console.log('error', error);
-    },
-    complete: () => {
-      console.log('Oracle Creation Completed');
-    },
-  });
+const createOracleObservable = factory.createOracle({
+  url: 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd',
+  method: 'GET',
+  headers: {
+    authorization: '%API_KEY%',
+  },
+  dataType: 'number', // [!code focus]
+  JSONPath: '$.ethereum.usd',
+  apiKey: 'MY_TEST_API_KEY',
+});
 ```
 
 ### JSONPath
@@ -226,28 +162,16 @@ const web3Provider = {} as any;
 const factory = new IExecOracleFactory(web3Provider);
 
 // ---cut---
-const createOracleRes = factory
-  .createOracle({
-    url: 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd',
-    method: 'GET',
-    headers: {
-      authorization: '%API_KEY%',
-    },
-    dataType: 'number',
-    JSONPath: '$.ethereum.usd', // [!code focus]
-    apiKey: 'MY_TEST_API_KEY',
-  })
-  .subscribe({
-    next: (data) => {
-      console.log('next', data);
-    },
-    error: (error) => {
-      console.log('error', error);
-    },
-    complete: () => {
-      console.log('Oracle Creation Completed');
-    },
-  });
+const createOracleObservable = factory.createOracle({
+  url: 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd',
+  method: 'GET',
+  headers: {
+    authorization: '%API_KEY%',
+  },
+  dataType: 'number',
+  JSONPath: '$.ethereum.usd', // [!code focus]
+  apiKey: 'MY_TEST_API_KEY',
+});
 ```
 
 ### apiKey
@@ -256,34 +180,26 @@ const createOracleRes = factory
 
 API key if required by the data source.
 
+The `apiKey` is protected an injected when an oracle is updated. `%API_KEY%` is
+used as a placeholder for the `apiKey` value in oracle public parameters url and
+headers.
+
 ```ts twoslash
 import { IExecOracleFactory } from '@iexec/iexec-oracle-factory-wrapper';
 const web3Provider = {} as any;
 const factory = new IExecOracleFactory(web3Provider);
 
 // ---cut---
-const createOracleRes = factory
-  .createOracle({
-    url: 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd',
-    method: 'GET',
-    headers: {
-      authorization: '%API_KEY%',
-    },
-    dataType: 'number',
-    JSONPath: '$.ethereum.usd',
-    apiKey: 'MY_TEST_API_KEY', // [!code focus]
-  })
-  .subscribe({
-    next: (data) => {
-      console.log('next', data);
-    },
-    error: (error) => {
-      console.log('error', error);
-    },
-    complete: () => {
-      console.log('Oracle Creation Completed');
-    },
-  });
+const createOracleObservable = factory.createOracle({
+  url: 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd',
+  method: 'GET',
+  headers: {
+    authorization: '%API_KEY%',
+  },
+  dataType: 'number',
+  JSONPath: '$.ethereum.usd',
+  apiKey: 'MY_TEST_API_KEY', // [!code focus]
+});
 ```
 
 ## Return value
@@ -292,11 +208,77 @@ const createOracleRes = factory
 
 ```ts twoslash
 import type {
-  CreateOracleMessage,
-  //
-  DeployDatasetMessage,
-  CreateParamSetMessage,
-  ComputeOracleIDMessage,
-  UploadParamSetMessage,
+  CreateOracleMessage, // any `data` the `next(data)` handler can receive
+
+  // all `data` types
+  ApiKeyEncryptionKeyCreatedMessage, // encryption key for `apiKey` value created
+  ApiKeyEncryptedMessage, // `apiKey` value encrypted
+  ApiKeyUploadedMessage, // `apiKey` encrypted value uploaded on IPFS
+  ApiKeyDatasetDeployRequestMessage, // requests the user to sign the API key's dataset deployment tx
+  ApiKeyDatasetDeploySuccessMessage, // API key's dataset deployed
+  ApiKeyPushSecretRequestMessage, // requests the user to push the encryption key in the SMS
+  ApiKeyPushSecretSuccessMessage, // encryption key pushed
+  ApiKeySignOrderRequestMessage, // requests the user to sign the dataset order
+  ApiKeySignOrderSuccessMessage, // dataset order signed
+  ApiKeyPublishOrderRequestMessage, // requests the user to publish the dataset order
+  ApiKeyPublishOrderSuccessMessage, // dataset order published
+  ParamSetCreatedMessage, // ParamSet created from inputs
+  OracleIDComputedMessage, // OracleId computed from ParamSet
+  ParamSetUploadedMessage, // ParamSet uploaded on IPFS
 } from '@iexec/iexec-oracle-factory-wrapper';
 ```
+
+::: tip
+
+Nothing happens before `subscribe()` is called on the returned observable.
+
+You can provide custom `next`, `complete` and `error` callback methods to
+`subscribe`
+
+```ts twoslash
+import {
+  IExecOracleFactory,
+  Observable,
+  ObservableNext,
+  ObservableComplete,
+  ObservableError,
+  CreateOracleMessage,
+} from '@iexec/iexec-oracle-factory-wrapper';
+
+const web3Provider = {} as any;
+const factory = new IExecOracleFactory(web3Provider);
+
+const createOracleObservable = factory.createOracle({
+  url: 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd',
+  method: 'GET',
+  headers: {
+    authorization: '%API_KEY%',
+  },
+  dataType: 'number',
+  JSONPath: '$.ethereum.usd',
+  apiKey: 'MY_TEST_API_KEY',
+});
+// ---cut---
+// method to call when the workflow goes to a new step
+const nextCallback: ObservableNext<CreateOracleMessage> = (data) => {
+  // your logic
+};
+
+// method to call when the workflow completes successfully
+const completeCallback: ObservableComplete = () => {
+  // your logic
+};
+
+// method to call when the workflow fails
+const errorCallback: ObservableError = (error: Error) => {
+  // your logic
+};
+
+createOracleObservable.subscribe({
+  next: nextCallback,
+  complete: completeCallback,
+  error: errorCallback,
+});
+```
+
+:::

--- a/tools/oracle-factory/methods/createOracle.md
+++ b/tools/oracle-factory/methods/createOracle.md
@@ -50,7 +50,7 @@ createOracleObservable.subscribe({
 import { type RawParams } from '@iexec/iexec-oracle-factory-wrapper';
 ```
 
-### url
+### url <RequiredBadge />
 
 `string`
 
@@ -74,7 +74,7 @@ const createOracleObservable = factory.createOracle({
 });
 ```
 
-### method
+### method <RequiredBadge />
 
 `'GET' | 'POST' | 'PUT' | 'DELETE'`
 
@@ -124,7 +124,7 @@ const createOracleObservable = factory.createOracle({
 ```
 <!-- prettier-ignore-end -->
 
-### dataType
+### dataType <RequiredBadge />
 
 `DataType`
 
@@ -148,7 +148,7 @@ const createOracleObservable = factory.createOracle({
 });
 ```
 
-### JSONPath
+### JSONPath <RequiredBadge />
 
 `string`
 

--- a/tools/oracle-factory/methods/createOracle.md
+++ b/tools/oracle-factory/methods/createOracle.md
@@ -44,8 +44,6 @@ createOracleObservable.subscribe({
 });
 ```
 
-                                   |
-
 ## Parameters
 
 ```ts twoslash

--- a/tools/oracle-factory/methods/readOracle.md
+++ b/tools/oracle-factory/methods/readOracle.md
@@ -12,7 +12,12 @@ the Ethereum price in USD:
 <a href="https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd">CoinGecko
 Ethereum API</a>.
 
-```js
+```ts twoslash
+import { IExecOracleFactory } from '@iexec/iexec-oracle-factory-wrapper';
+const web3Provider = {} as any;
+const readerOrFactory = new IExecOracleFactory(web3Provider);
+
+// ---cut---
 const readOracleRes = await readerOrFactory.readOracle(
   'QmbXhtjAJysMMA69KkB8KohsEDTZA2PXuhYdAQcHjjQFit'
 ); // Content ID of the Oracle
@@ -29,25 +34,124 @@ method.
 ## Parameters
 
 ```ts twoslash
-import { type ReadOracleParams } from '@iexec/iexec-oracle-factory-wrapper';
+import type { ReadOracleParams } from '@iexec/iexec-oracle-factory-wrapper';
 ```
 
-### cid
+### paramSet or paramSetCid or oracleId
 
-`paramSetOrCidOrOracleId`
+::: tip
 
-Content ID of the Oracle to be read.
+- The oracle `ParamSet` describes the parameters used to feed the oracle.
 
-```js
+- Any different `ParamSet` has a unique `ParamSetCid` which is the Content ID of
+  the document on IPFS. With a `ParamSetCid` anyone can retrieve the `ParamSet`
+  from IPFS.
+
+- The `OracleId` is the blockchain hash of the `ParamSet` it is used to store
+  and read the value of an oracle on the Oracle contract.
+
+:::
+
+- ParamSet of the Oracle to be read.
+
+```ts twoslash
+import {
+  IExecOracleFactory,
+  ParamSet,
+} from '@iexec/iexec-oracle-factory-wrapper';
+const web3Provider = {} as any;
+const readerOrFactory = new IExecOracleFactory(web3Provider);
+
+// ---cut---
+// [!code focus]
+const paramSet: ParamSet = {
+  method: 'GET', // [!code focus]
+  url: 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd', // [!code focus]
+  headers: { authorization: '%API_KEY%' }, // [!code focus]
+  body: '', // [!code focus]
+  dataset: '0x0eFf9Ba4304D5d3EB775cA9dB1F011e65C2eb0cE', // [!code focus]
+  JSONPath: '$.ethereum.usd', // [!code focus]
+  dataType: 'number', // [!code focus]
+}; // [!code focus]
+
 const readOracleRes = await readerOrFactory.readOracle(
-  'QmbXhtjAJysMMA69KkB8KohsEDTZA2PXuhYdAQcHjjQFit' // [!code focus]
+  paramSet // [!code focus]
+);
+```
+
+- ParamSet CID of the Oracle to be read.
+
+```ts twoslash
+import {
+  IExecOracleFactory,
+  ParamSetCID,
+} from '@iexec/iexec-oracle-factory-wrapper';
+const web3Provider = {} as any;
+const readerOrFactory = new IExecOracleFactory(web3Provider);
+
+// ---cut---
+const paramSetCid: ParamSetCID =
+  'QmbXhtjAJysMMA69KkB8KohsEDTZA2PXuhYdAQcHjjQFit';
+
+const readOracleRes = await readerOrFactory.readOracle(
+  paramSetCid // [!code focus]
+);
+```
+
+- Oracle ID of the Oracle to be read.
+
+```ts twoslash
+import {
+  IExecOracleFactory,
+  OracleID,
+} from '@iexec/iexec-oracle-factory-wrapper';
+const web3Provider = {} as any;
+const readerOrFactory = new IExecOracleFactory(web3Provider);
+
+// ---cut---
+const oracleId: OracleID =
+  '0xf0f370ad33d1e3e8e2d8df7197c40f62b5bc403553b103858359687491234491';
+
+const readOracleRes = await readerOrFactory.readOracle(
+  oracleId, // [!code focus]
+  {
+    dataType: 'number', // When reading an oracle from its OracleID, the dataType must be specified.
+  }
+);
+```
+
+### options
+
+#### dataType
+
+When reading an oracle from its OracleID, the dataType must be specified.
+
+```ts twoslash
+import {
+  IExecOracleFactory,
+  OracleID,
+  DataType
+} from '@iexec/iexec-oracle-factory-wrapper';
+const web3Provider = {} as any;
+const readerOrFactory = new IExecOracleFactory(web3Provider);
+
+// ---cut---
+const oracleId: OracleID =
+  '0xf0f370ad33d1e3e8e2d8df7197c40f62b5bc403553b103858359687491234491';
+const dataType: DataType = "number"
+
+const readOracleRes = await readerOrFactory.readOracle(
+  oracleId, // [!code focus]
+  { // [!code focus]
+    dataType, // [!code focus]
+  } // [!code focus]
 );
 ```
 
 ## Return value
 
-```ts twoslash
-import { type OracleValue } from '@iexec/iexec-oracle-factory-wrapper';
-```
-
 `OracleValue`
+
+```ts twoslash
+import type { OracleValue } from '@iexec/iexec-oracle-factory-wrapper';
+```

--- a/tools/oracle-factory/methods/readOracle.md
+++ b/tools/oracle-factory/methods/readOracle.md
@@ -54,6 +54,7 @@ import type { ReadOracleParams } from '@iexec/iexec-oracle-factory-wrapper';
 
 - ParamSet of the Oracle to be read.
 
+<!-- prettier-ignore-start -->
 ```ts twoslash
 import {
   IExecOracleFactory,
@@ -63,8 +64,7 @@ const web3Provider = {} as any;
 const readerOrFactory = new IExecOracleFactory(web3Provider);
 
 // ---cut---
-// [!code focus]
-const paramSet: ParamSet = {
+const paramSet: ParamSet = { // [!code focus]
   method: 'GET', // [!code focus]
   url: 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd', // [!code focus]
   headers: { authorization: '%API_KEY%' }, // [!code focus]
@@ -78,6 +78,7 @@ const readOracleRes = await readerOrFactory.readOracle(
   paramSet // [!code focus]
 );
 ```
+<!-- prettier-ignore-end -->
 
 - ParamSet CID of the Oracle to be read.
 
@@ -126,11 +127,12 @@ const readOracleRes = await readerOrFactory.readOracle(
 
 When reading an oracle from its OracleID, the dataType must be specified.
 
+<!-- prettier-ignore-start -->
 ```ts twoslash
 import {
   IExecOracleFactory,
   OracleID,
-  DataType
+  DataType,
 } from '@iexec/iexec-oracle-factory-wrapper';
 const web3Provider = {} as any;
 const readerOrFactory = new IExecOracleFactory(web3Provider);
@@ -138,15 +140,16 @@ const readerOrFactory = new IExecOracleFactory(web3Provider);
 // ---cut---
 const oracleId: OracleID =
   '0xf0f370ad33d1e3e8e2d8df7197c40f62b5bc403553b103858359687491234491';
-const dataType: DataType = "number"
+const dataType: DataType = 'number';
 
 const readOracleRes = await readerOrFactory.readOracle(
-  oracleId, // [!code focus]
+  oracleId,
   { // [!code focus]
     dataType, // [!code focus]
   } // [!code focus]
 );
 ```
+<!-- prettier-ignore-end -->
 
 ## Return value
 

--- a/tools/oracle-factory/methods/readOracle.md
+++ b/tools/oracle-factory/methods/readOracle.md
@@ -37,7 +37,7 @@ method.
 import type { ReadOracleParams } from '@iexec/iexec-oracle-factory-wrapper';
 ```
 
-### paramSet or paramSetCid or oracleId
+### paramSet or paramSetCid or oracleId <RequiredBadge />
 
 ::: tip
 

--- a/tools/oracle-factory/methods/updateOracle.md
+++ b/tools/oracle-factory/methods/updateOracle.md
@@ -51,7 +51,7 @@ updateOracleObservable.subscribe({
 
 ## Parameters
 
-### paramSet or paramSetCid
+### paramSet or paramSetCid <RequiredBadge />
 
 ::: tip
 

--- a/tools/oracle-factory/methods/updateOracle.md
+++ b/tools/oracle-factory/methods/updateOracle.md
@@ -75,7 +75,7 @@ const web3Provider = {} as any;
 const factory = new IExecOracleFactory(web3Provider);
 
 // ---cut---
-const paramSet: ParamSet = { //[!code focus]
+const paramSet: ParamSet = { // [!code focus]
   JSONPath: "$['ethereum']['usd']", // [!code focus]
   body: '', // [!code focus]
   dataType: 'number', // [!code focus]

--- a/tools/oracle-factory/methods/updateOracle.md
+++ b/tools/oracle-factory/methods/updateOracle.md
@@ -65,6 +65,7 @@ updateOracleObservable.subscribe({
 
 - ParamSet of the Oracle to update.
 
+<!-- prettier-ignore-start -->
 ```ts twoslash
 import {
   IExecOracleFactory,
@@ -74,7 +75,7 @@ const web3Provider = {} as any;
 const factory = new IExecOracleFactory(web3Provider);
 
 // ---cut---
-const paramSet: ParamSet = {
+const paramSet: ParamSet = { //[!code focus]
   JSONPath: "$['ethereum']['usd']", // [!code focus]
   body: '', // [!code focus]
   dataType: 'number', // [!code focus]
@@ -82,12 +83,13 @@ const paramSet: ParamSet = {
   headers: {}, // [!code focus]
   method: 'GET', // [!code focus]
   url: 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd', // [!code focus]
-};
+}; // [!code focus]
 
 const updateOracleObservable = factory.updateOracle(
   paramSet // [!code focus]
 );
 ```
+<!-- prettier-ignore-end -->
 
 - ParamSet CID of the Oracle to update.
 

--- a/tools/oracle-factory/methods/updateOracle.md
+++ b/tools/oracle-factory/methods/updateOracle.md
@@ -167,7 +167,7 @@ const updateOracleObservable = factory.updateOracle(
 
 ```ts twoslash
 import type {
-  UpdateOracleMessage, // any the `data` the `next(data)` handler can receive
+  UpdateOracleMessage, // any `data` the `next(data)` handler can receive
 
   // all `data` types
   EnsureParamsMessage, // check ParamSet can be found on IPFS

--- a/tools/oracle-factory/methods/updateOracle.md
+++ b/tools/oracle-factory/methods/updateOracle.md
@@ -12,95 +12,122 @@ the Ethereum price in USD:
 <a href="https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd">CoinGecko
 Ethereum API</a>.
 
-```js
-const updateOracleRes = factory
-  .updateOracle({
-    cid: 'QmbXhtjAJysMMA69KkB8KohsEDTZA2PXuhYdAQcHjjQFit',
+```ts twoslash
+import { IExecOracleFactory } from '@iexec/iexec-oracle-factory-wrapper';
+const web3Provider = {} as any;
+const factory = new IExecOracleFactory(web3Provider);
+
+// ---cut---
+// create an observable
+const updateOracleObservable = factory.updateOracle(
+  {
+    JSONPath: "$['ethereum']['usd']",
+    body: '',
+    dataType: 'number',
+    dataset: '0x0000000000000000000000000000000000000000',
+    headers: {},
+    method: 'GET',
+    url: 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd',
+  },
+  {
     workerpool: '0xa5de76...',
-    targetBlockchains: ['134', '137'],
-  })
-  .subscribe({
-    next: (data) => {
-      console.log('next', data);
-    },
-    error: (error) => {
-      console.log('error', error);
-    },
-    complete: () => {
-      console.log('Oracle update Completed');
-    },
-  });
+    targetBlockchains: [137],
+  }
+);
+
+// subscribe to the observable and start the workflow
+updateOracleObservable.subscribe({
+  next: (data) => {
+    console.log('next', data);
+  },
+  error: (error) => {
+    console.log('error', error);
+  },
+  complete: () => {
+    console.log('Oracle update Completed');
+  },
+});
 ```
-
-## Return values during creation process
-
-These are the possible events iExec may send to the subscriber:
-
-| message                              | sent                  | additional entries                                                                                                         |
-| ------------------------------------ | --------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| ENSURE_PARAMS                        | once                  |                                                                                                                            |
-| ENSURE_PARAMS_SUCCESS                | once                  | paramSet: Object<br/> cid: String                                                                                          |
-| FETCH_APP_ORDER                      | once                  |                                                                                                                            |
-| FETCH_APP_ORDER_SUCCESS              | once                  | order: Object                                                                                                              |
-| FETCH_DATASET_ORDER                  | once if using dataset |                                                                                                                            |
-| FETCH_DATASET_ORDER_SUCCESS          | once if using dataset | order: Object                                                                                                              |
-| FETCH_WORKERPOOL_ORDER               | once                  |                                                                                                                            |
-| FETCH_WORKERPOOL_ORDER_SUCCESS       | once                  | order: Object                                                                                                              |
-| REQUEST_ORDER_SIGNATURE_SIGN_REQUEST | once                  | order: Object                                                                                                              |
-| REQUEST_ORDER_SIGNATURE_SUCCESS      | once                  | order: Object                                                                                                              |
-| MATCH_ORDERS_SIGN_TX_REQUEST         | once                  | apporder: Object<br/> datasetorder: Object<br/> workerpoolorder: Object<br/> requestorder: Object                          |
-| MATCH_ORDERS_SUCCESS                 | once                  | dealid: String<br/> txHash: String                                                                                         |
-| TASK_UPDATED                         | once per task update  | dealid: String<br/> taskid: String<br/> status: 'UNSET' \| 'ACTIVE' \| 'REVEALING' \| 'COMPLETED' \| 'TIMEOUT' \| 'FAILED' |
-| TASK_COMPLETED                       | once                  | dealid: String<br/> taskid: String<br/> status: String                                                                     |
 
 ## Parameters
 
-### cid
+### paramSet or paramSetCid
+
+::: tip
+
+- The oracle `ParamSet` describes the parameters used to feed the oracle.
+
+- Any different `ParamSet` has a unique `ParamSetCid` which is the Content ID of
+  the document on IPFS. With a `ParamSetCid` anyone can retrieve the `ParamSet`
+  from IPFS.
+
+:::
+
+- ParamSet of the Oracle to update.
+
+```ts twoslash
+import {
+  IExecOracleFactory,
+  ParamSet,
+} from '@iexec/iexec-oracle-factory-wrapper';
+const web3Provider = {} as any;
+const factory = new IExecOracleFactory(web3Provider);
+
+// ---cut---
+const paramSet: ParamSet = {
+  JSONPath: "$['ethereum']['usd']", // [!code focus]
+  body: '', // [!code focus]
+  dataType: 'number', // [!code focus]
+  dataset: '0x0000000000000000000000000000000000000000', // [!code focus]
+  headers: {}, // [!code focus]
+  method: 'GET', // [!code focus]
+  url: 'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd', // [!code focus]
+};
+
+const updateOracleObservable = factory.updateOracle(
+  paramSet // [!code focus]
+);
+```
 
 Content ID of the Oracle that needs to be updated.
 
-```js
-const updateOracleRes = factory
-  .updateOracle({
-    cid: 'QmbXhtjAJysMMA69KkB8KohsEDTZA2PXuhYdAQcHjjQFit', // [!code focus]
-    workerpool: '0xa5de76...',
-    targetBlockchains: ['134', '137'],
-  })
-  .subscribe({
-    next: (data) => {
-      console.log('next', data);
-    },
-    error: (error) => {
-      console.log('error', error);
-    },
-    complete: () => {
-      console.log('Oracle update Completed');
-    },
-  });
+```ts twoslash
+import {
+  IExecOracleFactory,
+  ParamSetCID,
+} from '@iexec/iexec-oracle-factory-wrapper';
+const web3Provider = {} as any;
+const factory = new IExecOracleFactory(web3Provider);
+
+// ---cut---
+const paramSetCid: ParamSetCID = // [!code focus]
+  'QmbeY27w6dKxNQnGXih4AaotgNY3XuZ2yzbi2ZWQfRApqs'; // [!code focus]
+
+const updateOracleObservable = factory.updateOracle(
+  paramSetCid // [!code focus]
+);
 ```
 
 ### workerpool
 
 Address of the workerpool that should perform the update.
 
-```js
-const updateOracleRes = factory
-  .updateOracle({
-    cid: 'QmbXhtjAJysMMA69KkB8KohsEDTZA2PXuhYdAQcHjjQFit',
+```ts twoslash
+import {
+  IExecOracleFactory,
+  ParamSetCID,
+} from '@iexec/iexec-oracle-factory-wrapper';
+const web3Provider = {} as any;
+const factory = new IExecOracleFactory(web3Provider);
+
+// ---cut---
+const updateOracleObservable = factory.updateOracle(
+  'QmbXhtjAJysMMA69KkB8KohsEDTZA2PXuhYdAQcHjjQFit',
+  {
     workerpool: '0xa5de76...', // [!code focus]
-    targetBlockchains: ['134', '137'],
-  })
-  .subscribe({
-    next: (data) => {
-      console.log('next', data);
-    },
-    error: (error) => {
-      console.log('error', error);
-    },
-    complete: () => {
-      console.log('Oracle update Completed');
-    },
-  });
+    targetBlockchains: [137],
+  }
+);
 ```
 
 ::: tip
@@ -113,35 +140,98 @@ default workerpool for running confidential computations on the iExec platform.
 
 ### targetBlockchains
 
-Array of target blockchain IDs where the oracle is deployed. 137 for polygon,
-134 for iExec.
+Array of target blockchain chainId where the oracle is deployed. 1 for Ethereum
+mainnet, 137 for Polygon mainnet.
 
-```js
-const updateOracleRes = factory
-  .updateOracle({
-    cid: 'QmbXhtjAJysMMA69KkB8KohsEDTZA2PXuhYdAQcHjjQFit',
+```ts twoslash
+import {
+  IExecOracleFactory,
+  ParamSetCID,
+} from '@iexec/iexec-oracle-factory-wrapper';
+const web3Provider = {} as any;
+const factory = new IExecOracleFactory(web3Provider);
+
+// ---cut---
+const updateOracleObservable = factory.updateOracle(
+  'QmbXhtjAJysMMA69KkB8KohsEDTZA2PXuhYdAQcHjjQFit',
+  {
     workerpool: '0xa5de76...',
-    targetBlockchains: ['134', '137'], // [!code focus]
-  })
-  .subscribe({
-    next: (data) => {
-      console.log('next', data);
-    },
-    error: (error) => {
-      console.log('error', error);
-    },
-    complete: () => {
-      console.log('Oracle update Completed');
-    },
-  });
+    targetBlockchains: [1, 137], // [!code focus]
+  }
+);
 ```
 
 ## Return value
 
-```json
-{
-  "dealid": "0x86e1d2b13cd176f86b2c9d10931bc20dba0d626f1dac07dd76c1b1cec569f232",
-  "taskid": "0x90a100c10780f1d0595dd9e37dc1655eb66f192bf1b2b31d719a6ca3c6b62d07",
-  "status": "REVEALING"
-}
+`Observable<UpdateOracleMessage>`
+
+```ts twoslash
+import type {
+  UpdateOracleMessage, // any the `data` the `next(data)` handler can receive
+
+  // all `data` types
+  EnsureParamsMessage, // check ParamSet can be found on IPFS
+  EnsureParamsUploadMessage, // the ParamSet will be uploaded on IPFS
+  EnsureParamsSuccessMessage, // ParamSet exists on IPFS
+  FetchAppOrderMessage, // fetching app order
+  FetchAppOrderSuccessMessage, // app order found
+  FetchDatasetOrderMessage, // fetching dataset order (only for oracles using API key dataset)
+  FetchDatasetOrderSuccessMessage, // app order found (only for oracles using API key dataset)
+  FetchWorkerpoolOrderMessage, // fetching workerpool order
+  FetchWorkerpoolOrderSuccessMessage, // app workerpool found
+  RequestOrderSignatureSignRequestMessage, // asking the user to sign the request order
+  RequestOrderSignatureSuccessMessage, //
+  MatchOrdersSignTxRequestMessage, // asking the user to sign the transaction to match the orders and make a deal
+  MatchOrdersSuccessMessage, // orders matched
+  TaskUpdatedMessage, // notifies a task status change
+  UpdateTaskCompletedMessage, // the oracle update task is completed
+} from '@iexec/iexec-oracle-factory-wrapper';
 ```
+
+::: tip
+
+Nothing happens before `subscribe()` is called on the returned observable.
+
+You can provide custom `next`, `complete` and `error` callback methods to
+`subscribe`
+
+```ts twoslash
+import {
+  IExecOracleFactory,
+  Observable,
+  ObservableNext,
+  ObservableComplete,
+  ObservableError,
+  UpdateOracleMessage,
+} from '@iexec/iexec-oracle-factory-wrapper';
+
+const web3Provider = {} as any;
+const factory = new IExecOracleFactory(web3Provider);
+
+const updateOracleObservable = factory.updateOracle(
+  'QmbXhtjAJysMMA69KkB8KohsEDTZA2PXuhYdAQcHjjQFit'
+);
+// ---cut---
+// method to call when the workflow goes to a new step
+const nextCallback: ObservableNext<UpdateOracleMessage> = (data) => {
+  // your logic
+};
+
+// method to call when the workflow completes successfully
+const completeCallback: ObservableComplete = () => {
+  // your logic
+};
+
+// method to call when the workflow fails
+const errorCallback: ObservableError = (error: Error) => {
+  // your logic
+};
+
+updateOracleObservable.subscribe({
+  next: nextCallback,
+  complete: completeCallback,
+  error: errorCallback,
+});
+```
+
+:::

--- a/tools/oracle-factory/methods/updateOracle.md
+++ b/tools/oracle-factory/methods/updateOracle.md
@@ -89,7 +89,7 @@ const updateOracleObservable = factory.updateOracle(
 );
 ```
 
-Content ID of the Oracle that needs to be updated.
+- ParamSet CID of the Oracle to update.
 
 ```ts twoslash
 import {


### PR DESCRIPTION
Add `twoslash` in oracle factory documentation section.

This PR relies on https://github.com/iExecBlockchainComputing/iexec-oracle-factory-wrapper/pull/45 which includes some cleaning and new exported types.

Preview: https://documentation-tools-h1aablbl3-i-exec.vercel.app/